### PR TITLE
internal/ovsexporter: fix type of masks present metric

### DIFF
--- a/internal/ovsexporter/datapath.go
+++ b/internal/ovsexporter/datapath.go
@@ -30,7 +30,7 @@ type datapathCollector struct {
 	StatsLostTotal             *prometheus.Desc
 	StatsFlows                 *prometheus.Desc
 	MegaflowStatsMaskHitsTotal *prometheus.Desc
-	MegaflowStatsMasksTotal    *prometheus.Desc
+	MegaflowStatsMasks         *prometheus.Desc
 
 	listDatapaths func() ([]ovsnl.Datapath, error)
 }
@@ -77,8 +77,8 @@ func newDatapathCollector(fn func() ([]ovsnl.Datapath, error)) prometheus.Collec
 			labels, nil,
 		),
 
-		MegaflowStatsMasksTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "megaflow_stats_masks_total"),
+		MegaflowStatsMasks: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, "megaflow_stats_masks"),
 			"Number of megaflow masks present.",
 			labels, nil,
 		),
@@ -95,7 +95,7 @@ func (c *datapathCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.StatsLostTotal,
 		c.StatsFlows,
 		c.MegaflowStatsMaskHitsTotal,
-		c.MegaflowStatsMasksTotal,
+		c.MegaflowStatsMasks,
 	}
 
 	for _, d := range ds {
@@ -144,8 +144,8 @@ func (c *datapathCollector) Collect(ch chan<- prometheus.Metric) {
 				v: d.MegaflowStats.MaskHits,
 			},
 			{
-				d: c.MegaflowStatsMasksTotal,
-				t: prometheus.CounterValue,
+				d: c.MegaflowStatsMasks,
+				t: prometheus.GaugeValue,
 				v: uint64(d.MegaflowStats.Masks),
 			},
 		}

--- a/internal/ovsexporter/datapath_test.go
+++ b/internal/ovsexporter/datapath_test.go
@@ -81,7 +81,7 @@ func Test_datapathCollector(t *testing.T) {
 				// Only bother to check that the hits total metric is present for
 				// both datapaths, to reduce clutter here.
 				`openvswitch_datapath_megaflow_stats_mask_hits_total{datapath="ovs-system"} 5`,
-				`openvswitch_datapath_megaflow_stats_masks_total{datapath="ovs-system"} 6`,
+				`openvswitch_datapath_megaflow_stats_masks{datapath="ovs-system"} 6`,
 				`openvswitch_datapath_stats_flows{datapath="ovs-system"} 4`,
 				`openvswitch_datapath_stats_hits_total{datapath="ovs-system"} 1`,
 				`openvswitch_datapath_stats_hits_total{datapath="ovs-test"} 99`,


### PR DESCRIPTION
Not totally sure what I was thinking, but this should be a gauge instead.  Oops!

```
topk($count, openvswitch_datapath_megaflow_stats_masks_total{job=~"prod-openvswitch_exporter-.*"})
```

![selection217](https://user-images.githubusercontent.com/1926905/40199367-35bc2fcc-59e7-11e8-9d0a-7793a431bcb1.png)
